### PR TITLE
Fix: Move "Missing transfers?" and "New Transfer" buttons to the footer

### DIFF
--- a/src/html/landing.html
+++ b/src/html/landing.html
@@ -26,14 +26,6 @@
         <button data-behavior="landingSubmit" class="full-width">
           Begin new transfer
         </button>
-        <button
-          type="button"
-          class="link button--missing-transfer"
-          data-behavior="showAutoSyncTransfersModal"
-          style="display: none;"
-        >
-          Scan my transfer history
-        </button>
       </div>
     </form>
     <p class="create-account">
@@ -46,6 +38,15 @@
       >.
     </p>
   </div>
+  <footer class="landing-footer">
+    <button
+      type="button"
+      class="link button--missing-transfer"
+      data-behavior="showAutoSyncTransfersModal"
+    >
+      Missing transfers?
+    </button>
+  </footer>
 </div>
 <style>
   .landing {
@@ -95,20 +96,28 @@
   .cta-container {
     margin-top: var(--spacing-xxl);
   }
-  .cta-container .button--missing-transfer {
+  .landing-footer {
+    text-align: center;
+    margin-top: 20px;
+  }
+  
+  .landing-footer .button--missing-transfer {
     font-size: var(--fs-body);
     font-weight: var(--fw-regular);
-    margin-top: 0.5em;
+    color: var(--blue-500);
+    text-decoration: underline;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 10px;
   }
 </style>
 <script>
   async function renderLanding() {
     if (window.ethInitialized && window.nearInitialized) {
       window.dom.find("landingSubmit").disabled = false;
-      window.dom.show('showAutoSyncTransfersModal')
     } else {
       // window.dom.show("landing");
-      window.dom.hide('showAutoSyncTransfersModal')
       window.dom.find("landingSubmit").disabled = true;
       return;
     }

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -9,20 +9,20 @@
     <!-- TODO: <nav> -->
   </header>
   <div class="transfers__wrapper">
-    <div class="button-wrapper">
-      <button
-        class="button--new-transfer full-width"
-        data-behavior="newTransfer"
-      >
-        + New Transfer
-      </button>
-    </div>
     <div data-behavior="transfers-container"></div>
   </div>
-  <p style="margin-top: 2em; font-size: small; text-align: center">
-    Need help? Join our
-    <a href="https://t.me/AuroraSupport_bot" target="_blank" rel="noopener noreferrer">support telegram channel</a>
-  </p>
+  <footer class="transfers-footer">
+    <button
+      class="button--new-transfer"
+      data-behavior="newTransfer"
+    >
+      + New Transfer
+    </button>
+    <p style="margin-top: 1em; font-size: small;">
+      Need help? Join our
+      <a href="https://t.me/AuroraSupport_bot" target="_blank" rel="noopener noreferrer">support telegram channel</a>
+    </p>
+  </footer>
   <div data-behavior="deleteModal" class="modal" style="display: none">
     <div class="modal__container">
       <div class="modal-image__container">
@@ -111,18 +111,27 @@
       text-decoration: underline;
     }
 
-    .transfers__wrapper .button-wrapper {
+    .transfers-footer {
+      text-align: center;
+      margin-top: 2em;
       padding: 0 var(--spacing-m);
     }
 
-    @media (min-width: 600px) {
-      .transfers__wrapper .button-wrapper {
-        padding: 0;
-      }
+    .transfers-footer .button--new-transfer {
+      background-color: var(--blue-500);
+      color: white;
+      border: none;
+      border-radius: var(--br-small);
+      padding: 12px 24px;
+      font-size: var(--fs-body);
+      font-weight: var(--fw-medium);
+      cursor: pointer;
     }
 
-    .transfers__wrapper .button--new-transfer {
-      margin-bottom: var(--spacing-m);
+    @media (min-width: 600px) {
+      .transfers-footer {
+        padding: 0;
+      }
     }
 
     .transfer.in-progress {


### PR DESCRIPTION
## Description
This PR addresses issue #1 by moving the "Missing transfers?" and "New Transfer" buttons to the footer of their respective pages.

### Changes made:
1. Moved the "Missing transfers?" button from the landing page form to a new footer section
2. Moved the "New Transfer" button from the top of the transfers page to a new footer section
3. Added appropriate styling for both buttons in their new locations
4. Ensured the "Missing transfers?" button is always visible in the footer (previously it was conditionally shown)

## Testing
The changes have been tested locally and the buttons now appear in the footer as requested.

Fixes #1