### PR TITLE
Update NEAR wallet creation URL to MyNearWallet testnet

### DIFF
--- a/src/html/landing.html
+++ b/src/html/landing.html
@@ -41,7 +41,7 @@
       <a
         target="_blank"
         rel="noopener noreferrer"
-        href="https://faucet.paras.id/"
+        href="https://testnet.mynearwallet.com/create"
         >here</a
       >.
     </p>


### PR DESCRIPTION
## Summary

This PR updates the NEAR wallet creation URL from the outdated `https://faucet.paras.id/` to the official `https://testnet.mynearwallet.com/create` URL.

## Problem

The current "here" link in the landing page directs users to `https://faucet.paras.id/` when they click "Need a NEAR account? Create one here." This URL appears to be outdated and may not provide the best user experience for creating NEAR testnet accounts.

## Solution

- Updated the URL in `src/html/landing.html` (line 44) from `https://faucet.paras.id/` to `https://testnet.mynearwallet.com/create`
- This change directs users to the official MyNearWallet testnet account creation page
- Maintains the same link behavior (opens in new tab with proper security attributes)

## Changes Made

- **File Modified**: `src/html/landing.html`
- **Line Changed**: Line 44
- **Change Type**: URL update only, no functional changes to the application

## Testing

- ✅ Verified the new URL is accessible and functional
- ✅ Confirmed the link opens in a new tab as expected
- ✅ No breaking changes to existing functionality
- ✅ Application builds and runs successfully with the change

## Impact

- **User Experience**: Users will now be directed to the official NEAR wallet creation page
- **Functionality**: No impact on existing bridge functionality
- **Compatibility**: Fully backward compatible

## Screenshots

The change affects the "here" link in this section:
```
Need a NEAR account? Create one here.
```

## Related Issues

This addresses the need to update the wallet creation URL to use the current official MyNearWallet service for testnet account creation.

---

**Type of Change**: 🔗 URL Update
**Breaking Change**: ❌ No
**Documentation Update**: ❌ Not Required

@Pinellia577 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ff031b9da2644892af3be180d91afc30)